### PR TITLE
fix: removed annoying eslint rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -13,7 +13,6 @@ module.exports = {
   plugins: ["@typescript-eslint"],
   rules: {
     indent: ["warn", 2],
-    "linebreak-style": ["warn", "unix"],
     semi: ["warn", "always"],
     "@typescript-eslint/no-unused-vars": [
       "warn",


### PR DESCRIPTION
removed eslint rule to warn the use of CRLF instead of LF. Useful in general, but annoying for windows user